### PR TITLE
Add compatibility with gradle 5.2 (current master)

### DIFF
--- a/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt
+++ b/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt
@@ -79,8 +79,8 @@ Add a dependency to com.google.errorprone:javac with the appropriate version cor
 
         val noJavacDependencyNotified = AtomicBoolean()
         project.tasks.withType<JavaCompile>().configureElement {
-            val errorproneOptions =
-                (options as ExtensionAware).extensions.create(ErrorProneOptions.NAME, ErrorProneOptions::class.java)
+            val errorproneOptions = ErrorProneOptions()
+            (options as ExtensionAware).extensions.add(ErrorProneOptions.NAME, errorproneOptions)
             options
                 .compilerArgumentProviders
                 .add(ErrorProneCompilerArgumentProvider(errorproneOptions))


### PR DESCRIPTION
With gradle 5.2 there's a bit more validation around dependency injection which requires javax.inject annotations to be present and doesn't play nicely with kotlin. Instead of relying on injection we instantiate the options object directly.