### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env: GRADLE_VERSION=4.7
 
 install: true
-script: ./gradlew build -Ptest.gradle-version=$GRADLE_VERSION
+script: ./gradlew --scan build -Ptest.gradle-version=$GRADLE_VERSION
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+    id("com.gradle.build-scan") version "2.1"
     `java-gradle-plugin`
     `kotlin-dsl`
     `maven-publish`
@@ -122,6 +123,11 @@ pluginBundle {
         groupId = project.group.toString()
         artifactId = project.name
     }
+}
+
+buildScan {
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
 }
 
 val ktlint by configurations.creating


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.