### PR TITLE
Use name-only path sensitivity for the javac task input

### DIFF
--- a/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt
+++ b/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt
@@ -23,6 +23,7 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.compile.ForkOptions
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.kotlin.dsl.* // ktlint-disable no-wildcard-imports
@@ -89,7 +90,7 @@ Add a dependency to com.google.errorprone:javac with the appropriate version cor
             if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
                 // We don't know yet whether the task will use the same JVM (and need the Error Prone javac),
                 // but chances are really high that this will be the case, so configure task inputs anyway.
-                inputs.files(javacConfiguration)
+                inputs.files(javacConfiguration).withPropertyName(JAVAC_CONFIGURATION_NAME).withPathSensitivity(PathSensitivity.NAME_ONLY)
                 doFirst("configure errorprone in bootclasspath") {
                     if (options.errorprone.isEnabled &&
                         (!options.isFork || (options.forkOptions.javaHome == null && options.forkOptions.executable == null))) {


### PR DESCRIPTION
If you're trying to use the Gradle build cache across different
machines, then this input is currently problematic because any
difference in its absolute path will result in a different cache key.
The file it's checking is in your Gradle cache in your user home,
so it's probably not going to be the same across different people's
computers. Setting the path sensitivity to NAME_ONLY removes the
difference across environments while maintaining the check for
differing file contents.

Also add a property name to the input to assist with debugging
cache inputs; otherwise, it just shows up as "$1", which is not
terribly helpful.