### PR TITLE
Fix Java 16 bug when using TimeZone class

### DIFF
--- a/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt
+++ b/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt
@@ -65,7 +65,8 @@ Add a dependency to com.google.errorprone:javac with the appropriate version cor
             "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
             "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
             "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
+            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED"
         )
     }
 

--- a/src/test/kotlin/net/ltgt/gradle/errorprone/AbstractPluginIntegrationTest.kt
+++ b/src/test/kotlin/net/ltgt/gradle/errorprone/AbstractPluginIntegrationTest.kt
@@ -77,6 +77,25 @@ abstract class AbstractPluginIntegrationTest {
         }
     }
 
+    protected fun writeTimeZoneJava16Source() {
+        File(testProjectDir.newFolder("src", "main", "java", "test"), "TimeZoneJava16.java").apply {
+            createNewFile()
+            writeText(
+                """
+                package test;
+
+                import java.util.TimeZone;
+
+                public class TimeZoneJava16 {
+                    public TimeZone foo() {
+                        return TimeZone.getTimeZone("PST");
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
     protected fun buildWithArgs(vararg tasks: String): BuildResult {
         return prepareBuild(*tasks)
             .build()

--- a/src/test/kotlin/net/ltgt/gradle/errorprone/ErrorPronePluginIntegrationTest.kt
+++ b/src/test/kotlin/net/ltgt/gradle/errorprone/ErrorPronePluginIntegrationTest.kt
@@ -56,6 +56,18 @@ class ErrorPronePluginIntegrationTest : AbstractPluginIntegrationTest() {
     }
 
     @Test
+    fun `compilation succeeds Java 16`() {
+        // given
+        writeTimeZoneJava16Source()
+
+        // when
+        val result = buildWithArgs("compileJava")
+
+        // then
+        assertThat(result.task(":compileJava")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
     fun `compilation fails`() {
         // given
         writeFailureSource()


### PR DESCRIPTION
The provided test fails under Java 16 without the addition of `--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED`

```
> Task :compileJava FAILED
/private/var/folders/jf/29g0fz_16w9_3y2db8ylkl540000gn/T/junit1380605189140352106/src/main/java/test/TimeZoneJava16.java:7: error: An unhandled exception was thrown by the Error Prone static analysis plugin.
        return TimeZone.getTimeZone("PST");
                                   ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.5.1
     BugPattern: ThreeLetterTimeZoneID
     Stack Trace:
     java.lang.IllegalAccessError: class com.google.errorprone.VisitorState (in unnamed module @0x51b6b93c) cannot access class com.sun.tools.javac.model.JavacElements (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.model to unnamed module @0x51b6b93c
  	at com.google.errorprone.VisitorState.getElements(VisitorState.java:244)
  	at com.google.errorprone.bugpatterns.ThreeLetterTimeZoneID.matchMethodInvocation(ThreeLetterTimeZoneID.java:79)
  	at com.google.errorprone.scanner.ErrorProneScanner.processMatchers(ErrorProneScanner.java:450)
```