### PR TITLE
Upgrade to `gradle-build-action@v2`

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -1,4 +1,3 @@
-#Bump
 name: CI
 
 on:
@@ -11,8 +10,6 @@ on:
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-  CACHE_DEBUG_ENABLED: true
-  CACHE_KEY_PREFIX: 'A-'
 
 # First build on Linux and Windows with JDK 8
 # Then run tests with various Gradle and JDKs versions (Linux only)
@@ -27,7 +24,7 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@releases/v2
         with:
           arguments: --scan build
 
@@ -48,7 +45,7 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@releases/v2
         with:
           arguments: --scan build
 
@@ -73,7 +70,7 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@releases/v2
         with:
           arguments: --scan test "-Ptest.gradle-version=${{ matrix.gradle }}"
 
@@ -113,7 +110,7 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@releases/v2
         with:
           arguments: --scan test "-Ptest.java-toolchain=${{ matrix.java }}"
 
@@ -151,7 +148,7 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@releases/v2
         with:
           arguments: --scan test -Ptest.java-toolchain=17 "-Ptest.gradle-version=${{ matrix.gradle }}"
 

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -11,6 +11,7 @@ on:
 env:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"
   CACHE_DEBUG_ENABLED: true
+  CACHE_KEY_PREFIX: 'A-'
 
 # First build on Linux and Windows with JDK 8
 # Then run tests with various Gradle and JDKs versions (Linux only)
@@ -65,12 +66,6 @@ jobs:
         gradle: [ '7.2', '7.1.1', '7.0.2', '6.8.3', '6.7.1', '6.6.1', '6.5.1', '6.4.1', '6.3', '6.2.2', '6.1.1', '6.0.1', '5.6.4', '5.5.1', '5.4.1', '5.3.1', '5.2.1' ]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache Gradle test wrapper (${{ matrix.gradle }})
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper/dists/gradle-${{ matrix.gradle }}-bin/
-          key: wrapper-${{ matrix.gradle }}
 
       - name: Setup environment
         run: echo "JAVA_HOME=${JAVA_HOME_8_X64}" | tee -a $GITHUB_ENV

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -10,6 +10,7 @@ on:
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+  CACHE_DEBUG_ENABLED: true
 
 # First build on Linux and Windows with JDK 8
 # Then run tests with various Gradle and JDKs versions (Linux only)

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -24,13 +24,9 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --scan build
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          dependencies-cache-key: '**/*.lockfile'
-          dependencies-cache-exact: true
 
       - name: Store reports
         if: always() && (steps.gradle-build.outcome == 'success' || steps.gradle-build.outcome == 'failure')
@@ -49,13 +45,9 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --scan build
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          dependencies-cache-key: '**/*.lockfile'
-          dependencies-cache-exact: true
 
       - name: Store reports
         if: always() && (steps.gradle-build.outcome == 'success' || steps.gradle-build.outcome == 'failure')
@@ -84,13 +76,9 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --scan test "-Ptest.gradle-version=${{ matrix.gradle }}"
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          dependencies-cache-key: '**/*.lockfile'
-          dependencies-cache-exact: true
 
       - name: Store reports
         if: always() && (steps.gradle-build.outcome == 'success' || steps.gradle-build.outcome == 'failure')
@@ -128,13 +116,9 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --scan test "-Ptest.java-toolchain=${{ matrix.java }}"
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          dependencies-cache-key: '**/*.lockfile'
-          dependencies-cache-exact: true
 
       - name: Store reports
         if: always() && (steps.gradle-build.outcome == 'success' || steps.gradle-build.outcome == 'failure')
@@ -170,13 +154,9 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --scan test -Ptest.java-toolchain=17 "-Ptest.gradle-version=${{ matrix.gradle }}"
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          dependencies-cache-key: '**/*.lockfile'
-          dependencies-cache-exact: true
 
       - name: Store reports
         if: always() && (steps.gradle-build.outcome == 'success' || steps.gradle-build.outcome == 'failure')

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -1,3 +1,4 @@
+#Bump
 name: CI
 
 on:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true


### PR DESCRIPTION
This PR upgrades the GitHub actions workflow to the latest v2 version (presently v2.0-beta.7). This new action has simpler configuration and does a better job of caching the Gradle User Home state between build invocations.

The build-cache was also enabled for the build, since the action will now persist the local build cache between workflow invocations.