### PR TITLE
Pass should-stop.ifError=FLOW in addition to compilePolicy=simple

### DIFF
--- a/src/integrationTest/resources/com/google/errorprone/sample/CPSChecker.java
+++ b/src/integrationTest/resources/com/google/errorprone/sample/CPSChecker.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2011 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.sample;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.ReturnTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ReturnTree;
+
+@BugPattern(
+    name = "CPSChecker",
+    summary = "Using 'return' is considered harmful",
+    explanation = "Please refactor your code into continuation passing style.",
+    severity = ERROR)
+public class CPSChecker extends BugChecker implements ReturnTreeMatcher {
+  @Override
+  public Description matchReturn(ReturnTree tree, VisitorState state) {
+    return describeMatch(tree);
+  }
+}

--- a/src/integrationTest/resources/com/google/errorprone/sample/EffectivelyFinalChecker.java
+++ b/src/integrationTest/resources/com/google/errorprone/sample/EffectivelyFinalChecker.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2011 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.sample;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.VariableTree;
+
+@BugPattern(
+    name = "EffectivelyFinalChecker",
+    summary = "All variables should be effectively final",
+    severity = ERROR)
+public class EffectivelyFinalChecker extends BugChecker implements VariableTreeMatcher {
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    if (ASTHelpers.isConsideredFinal(ASTHelpers.getSymbol(tree))) {
+      return NO_MATCH;
+    }
+    return describeMatch(tree);
+  }
+}

--- a/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt
+++ b/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt
@@ -201,7 +201,8 @@ internal class ErrorProneCompilerArgumentProvider(
 
     override fun asArguments(): Iterable<String> {
         return when {
-            errorproneOptions.isEnabled.getOrElse(false) -> listOf("-Xplugin:ErrorProne $errorproneOptions", "-XDcompilePolicy=simple")
+            // should-stop.ifError is for JDK 9+, shouldStopPolicyIfError for JDK 8; it's safe to indiscriminately pass both
+            errorproneOptions.isEnabled.getOrElse(false) -> listOf("-Xplugin:ErrorProne $errorproneOptions", "-XDcompilePolicy=simple", "-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
             else -> emptyList()
         }
     }


### PR DESCRIPTION
It fixes a few issues in all versions of Error Prone, and the next version will make it mandatory.