### PR TITLE
Update to Error Prone 2.46.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 # Try to maintain entries sorted alphabetically inside each "group".
 [versions]
-errorprone = "2.45.0"
+errorprone = "2.46.0"
 junitJupiter = "6.0.1"
 ktlint = "1.8.0"
 

--- a/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt
+++ b/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt
@@ -200,6 +200,7 @@ internal class ErrorProneCompilerArgumentProvider(
                     "-XDcompilePolicy=simple",
                     "-XDshould-stop.ifError=FLOW",
                     "-XDshouldStopPolicyIfError=FLOW",
+                    "-XDaddTypeAnnotationsToSymbol=true",
                 )
             }
 


### PR DESCRIPTION
And pass `-XDaddTypeAnnotationsToSymbol=true`, see https://github.com/google/error-prone/issues/5426.